### PR TITLE
Package Consistency

### DIFF
--- a/runtime/variable.go
+++ b/runtime/variable.go
@@ -346,7 +346,17 @@ func (v *OutVariable[T]) Set(ctx message.Context, value T) error {
 			return err
 		}
 		if lmo != nil {
-			return client.SetVariable(&variable{Scope: v.Scope, Name: v.Name.(string)}, lmo)
+
+			//The reason of Marshal & Unmarshal  id field of the LMO is capitalized which is ID,
+			//but robot expects "id"
+			m := make(map[string]interface{})
+			_lmo, err := json.Marshal(lmo)
+			if err != nil {
+				return err
+			}
+			json.Unmarshal(_lmo, &m)
+
+			return client.SetVariable(&variable{Scope: v.Scope, Name: v.Name.(string)}, m)
 		}
 
 	}


### PR DESCRIPTION
Previously, we were transmitting an LMO struct within the set variable method  to the Robot. However, the ID field was being received as capitalized by the Robot. To ensure consistency with other packages and maintain the ID field in an uncapitalized format, we've opted to send a map instead of the LMO struct. This change guarantees that the ID field is transmitted consistently as uncapitalized data which is "id"