### PR TITLE
Ignore GetRaw error

### DIFF
--- a/message/context.go
+++ b/message/context.go
@@ -8,11 +8,12 @@ import (
 	"github.com/tidwall/sjson"
 )
 
-type Option func(json.RawMessage) (json.RawMessage, error)
+type GetOption func(json.RawMessage) (json.RawMessage, error)
+type SetOption func(json.RawMessage) (json.RawMessage, error)
 
 var (
-	GetRaw func(json.RawMessage, ...Option) (json.RawMessage, error)
-	SetRaw func(json.RawMessage, ...Option) (json.RawMessage, error)
+	GetRaw func(json.RawMessage, ...GetOption) (json.RawMessage, error)
+	SetRaw func(json.RawMessage, ...SetOption) (json.RawMessage, error)
 )
 
 type Context interface {
@@ -23,8 +24,8 @@ type Context interface {
 	GetBool(path string) bool
 	GetInt(path string) int64
 	GetFloat(path string) float64
-	GetRaw(options ...Option) (json.RawMessage, error)
-	SetRaw(data json.RawMessage, options ...Option) error
+	GetRaw(options ...GetOption) (json.RawMessage, error)
+	SetRaw(data json.RawMessage, options ...SetOption) error
 	IsEmpty() bool
 }
 
@@ -81,11 +82,11 @@ func (msg *message) GetFloat(path string) float64 {
 	return msg.get(path).Float()
 }
 
-func (msg *message) GetRaw(options ...Option) (json.RawMessage, error) {
+func (msg *message) GetRaw(options ...GetOption) (json.RawMessage, error) {
 	return GetRaw(msg.data, options...)
 }
 
-func (msg *message) SetRaw(data json.RawMessage, options ...Option) (err error) {
+func (msg *message) SetRaw(data json.RawMessage, options ...SetOption) (err error) {
 	msg.data, err = SetRaw(data, options...)
 	return err
 }

--- a/message/context.go
+++ b/message/context.go
@@ -8,9 +8,11 @@ import (
 	"github.com/tidwall/sjson"
 )
 
+type Option func(json.RawMessage) (json.RawMessage, error)
+
 var (
-	GetRaw func(json.RawMessage) (json.RawMessage, error)
-	SetRaw func(json.RawMessage) (json.RawMessage, error)
+	GetRaw func(json.RawMessage, ...Option) (json.RawMessage, error)
+	SetRaw func(json.RawMessage, ...Option) (json.RawMessage, error)
 )
 
 type Context interface {
@@ -21,8 +23,8 @@ type Context interface {
 	GetBool(path string) bool
 	GetInt(path string) int64
 	GetFloat(path string) float64
-	GetRaw() (json.RawMessage, error)
-	SetRaw(data json.RawMessage) error
+	GetRaw(options ...Option) (json.RawMessage, error)
+	SetRaw(data json.RawMessage, options ...Option) error
 	IsEmpty() bool
 }
 
@@ -79,11 +81,11 @@ func (msg *message) GetFloat(path string) float64 {
 	return msg.get(path).Float()
 }
 
-func (msg *message) GetRaw() (json.RawMessage, error) {
-	return GetRaw(msg.data)
+func (msg *message) GetRaw(options ...Option) (json.RawMessage, error) {
+	return GetRaw(msg.data, options...)
 }
 
-func (msg *message) SetRaw(data json.RawMessage) (err error) {
+func (msg *message) SetRaw(data json.RawMessage, options ...Option) (err error) {
 	msg.data, err = SetRaw(data)
 	return err
 }

--- a/message/context.go
+++ b/message/context.go
@@ -86,7 +86,7 @@ func (msg *message) GetRaw(options ...Option) (json.RawMessage, error) {
 }
 
 func (msg *message) SetRaw(data json.RawMessage, options ...Option) (err error) {
-	msg.data, err = SetRaw(data)
+	msg.data, err = SetRaw(data, options...)
 	return err
 }
 

--- a/runtime/grpc.go
+++ b/runtime/grpc.go
@@ -105,7 +105,7 @@ func (m *GRPCServer) OnMessage(ctx context.Context, req *proto.OnMessageRequest)
 	}
 
 	if !msgCtx.IsEmpty() {
-		resp.OutMessage, err = msgCtx.GetRaw()
+		resp.OutMessage, _ = msgCtx.GetRaw()
 	}
 
 	time.Sleep(time.Duration(node.DelayAfter*1000) * time.Millisecond)

--- a/runtime/grpc.go
+++ b/runtime/grpc.go
@@ -105,7 +105,11 @@ func (m *GRPCServer) OnMessage(ctx context.Context, req *proto.OnMessageRequest)
 	}
 
 	if !msgCtx.IsEmpty() {
-		resp.OutMessage, _ = msgCtx.GetRaw()
+		msg, e := msgCtx.GetRaw()
+		if e != nil {
+			return nil, fmt.Errorf("get raw message failed with error: %+v", err.Error())
+		}
+		resp.OutMessage = msg
 	}
 
 	time.Sleep(time.Duration(node.DelayAfter*1000) * time.Millisecond)

--- a/runtime/message.go
+++ b/runtime/message.go
@@ -14,12 +14,6 @@ func init() {
 func getRaw(raw json.RawMessage) (json.RawMessage, error) {
 	if IsLMOCapable() {
 		return raw, nil
-
-		var err error
-		raw, err = UnpackMessageBytes(raw)
-		if err != nil {
-			return nil, err
-		}
 	}
 	return raw, nil
 }

--- a/runtime/message.go
+++ b/runtime/message.go
@@ -2,7 +2,6 @@ package runtime
 
 import (
 	"encoding/json"
-	"log"
 
 	"github.com/robomotionio/robomotion-go/message"
 )
@@ -13,7 +12,7 @@ func init() {
 }
 
 // DeserializeLMO for all data
-func WithUnpack() message.Option {
+func WithUnpack() message.GetOption {
 	return func(raw json.RawMessage) (json.RawMessage, error) {
 		if IsLMOCapable() {
 			var err error
@@ -27,7 +26,7 @@ func WithUnpack() message.Option {
 }
 
 // SerializeLMO for all data
-func WithPack() message.Option {
+func WithPack() message.SetOption {
 	return func(raw json.RawMessage) (json.RawMessage, error) {
 		if IsLMOCapable() {
 			var err error
@@ -41,27 +40,24 @@ func WithPack() message.Option {
 	}
 }
 
-func getRaw(raw json.RawMessage, options ...message.Option) (json.RawMessage, error) {
+func getRaw(raw json.RawMessage, options ...message.GetOption) (json.RawMessage, error) {
+	var err error
 	for _, opt := range options {
-		_raw, err := opt(raw)
+		raw, err = opt(raw)
 		if err != nil {
-			log.Printf("Option could not be applied %+v \n", err)
-			continue
+			return nil, err
 		}
-		raw = _raw
 	}
 	return raw, nil
 }
 
-func setRaw(raw json.RawMessage, options ...message.Option) (json.RawMessage, error) {
-
+func setRaw(raw json.RawMessage, options ...message.SetOption) (json.RawMessage, error) {
+	var err error
 	for _, opt := range options {
-		_raw, err := opt(raw)
+		raw, err = opt(raw)
 		if err != nil {
-			log.Printf("Option could not be applied %+v \n", err)
-			continue
+			return nil, err
 		}
-		raw = _raw
 	}
 	return raw, nil
 }

--- a/runtime/message.go
+++ b/runtime/message.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"encoding/json"
+	"log"
 
 	"github.com/robomotionio/robomotion-go/message"
 )
@@ -11,21 +12,56 @@ func init() {
 	message.SetRaw = setRaw
 }
 
-func getRaw(raw json.RawMessage) (json.RawMessage, error) {
-	if IsLMOCapable() {
+// DeserializeLMO for all data
+func WithUnpack() message.Option {
+	return func(raw json.RawMessage) (json.RawMessage, error) {
+		if IsLMOCapable() {
+			var err error
+			raw, err = UnpackMessageBytes(raw)
+			if err != nil {
+				return nil, err
+			}
+		}
 		return raw, nil
+	}
+}
+
+// SerializeLMO for all data
+func WithPack() message.Option {
+	return func(raw json.RawMessage) (json.RawMessage, error) {
+		if IsLMOCapable() {
+			var err error
+			raw, err = PackMessageBytes(raw)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		return raw, nil
+	}
+}
+
+func getRaw(raw json.RawMessage, options ...message.Option) (json.RawMessage, error) {
+	for _, opt := range options {
+		_raw, err := opt(raw)
+		if err != nil {
+			log.Printf("Option could not be applied %+v \n", err)
+			continue
+		}
+		raw = _raw
 	}
 	return raw, nil
 }
 
-func setRaw(data json.RawMessage) (json.RawMessage, error) {
-	if IsLMOCapable() {
-		var err error
-		data, err = PackMessageBytes(data)
-		if err != nil {
-			return nil, err
-		}
-	}
+func setRaw(raw json.RawMessage, options ...message.Option) (json.RawMessage, error) {
 
-	return data, nil
+	for _, opt := range options {
+		_raw, err := opt(raw)
+		if err != nil {
+			log.Printf("Option could not be applied %+v \n", err)
+			continue
+		}
+		raw = _raw
+	}
+	return raw, nil
 }


### PR DESCRIPTION
In the latest version, the err response of GetRaw method (which is nil everytime but necessary to solve cycling import) overwrites the err values of node.Handler.OnMessage(). So the package errors were ignoring. It has been solved when the overwrite part has been prevented. 