### PR TITLE
Gate LMOPack on capability check in OnMessage

### DIFF
--- a/runtime/grpc.go
+++ b/runtime/grpc.go
@@ -141,8 +141,10 @@ func (m *GRPCServer) OnMessage(ctx context.Context, req *proto.OnMessageRequest)
 			return nil, fmt.Errorf("get raw message failed with error: %+v", e.Error())
 		}
 
-		if packed, packErr := LMOPack(msg); packErr == nil {
-			msg = packed
+		if HasCapability(CapabilityLMO) {
+			if packed, packErr := LMOPack(msg); packErr == nil {
+				msg = packed
+			}
 		}
 
 		resp.OutMessage = msg


### PR DESCRIPTION
## Summary
- Wraps `LMOPack()` call in `OnMessage()` with `HasCapability(CapabilityLMO)` guard, matching the existing pattern in `variable.go`
- Defense-in-depth alongside the deskbot-side fix (robomotion-deskbot#2415) that gates `lmo_store_path` on robot capability
- Ensures `LMOPack` is a no-op when the robot lacks LMO capability, even if the store is somehow initialized

## Test plan
- [x] `go build ./...` passes
- [ ] Verify LMO-capable robots still pack messages correctly
- [ ] Verify non-LMO robots skip packing without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)