### PR TITLE
lmo: recursively resolve nested BlobRefs

### DIFF
--- a/runtime/lmo/store.go
+++ b/runtime/lmo/store.go
@@ -337,6 +337,18 @@ func (s *Store) resolveValue(value gjson.Result) ([]byte, bool, error) {
 		if err != nil {
 			return nil, false, err
 		}
+		// Recurse into resolved bytes so nested BlobRefs (from
+		// Pack's extractObject !modified whole-pack branch) are
+		// also unwrapped. Without this, an inner BlobRef envelope
+		// leaks to user code as a stub object and crashes with
+		// "TypeError: <field>.push is not a function".
+		nestedFixed, changed, err := s.resolveValue(resolved)
+		if err != nil {
+			return nil, false, err
+		}
+		if changed {
+			return nestedFixed, true, nil
+		}
 		return []byte(resolved.Raw), true, nil
 	}
 

--- a/runtime/lmo/store_test.go
+++ b/runtime/lmo/store_test.go
@@ -481,3 +481,120 @@ func TestBlobRefTypeObject(t *testing.T) {
 		}
 	}
 }
+
+// TestNestedBlobRef_SurvivesResolveAll pins the customer's iter-17 bug
+// pattern: when extractObject's !modified branch packs a whole container
+// as a single blob, the blob bytes preserve any pre-existing BlobRef
+// envelopes inside. Without recursive resolveValue, those nested
+// BlobRefs survive ResolveAll and surface upstream as stub objects.
+func TestNestedBlobRef_SurvivesResolveAll(t *testing.T) {
+	s, _ := newTestStore(t)
+
+	// Pack a "response" array (16 SOAP-ish entries, ~12 KB).
+	respElements := make([]string, 16)
+	for i := range respElements {
+		respElements[i] = `{"raw":"` + strings.Repeat("X", 680) +
+			`","sgkSicil":"s","sirketAdi":"ihl","sonucKod":"0"}`
+	}
+	respArr := []byte("[" + strings.Join(respElements, ",") + "]")
+	respRef, err := s.PutBlob(respArr)
+	if err != nil {
+		t.Fatalf("PutBlob: %v", err)
+	}
+	respEnv := `{"__ref":"` + respRef + `","__magic":20260301,"__size":12500,"__path":"test/flow","__type":"array","__len":16}`
+
+	// Build msg shape that triggers !modified whole-pack on api: api > 4 KB
+	// but no individual child reaches 4 KB.
+	loginEntries := make([]string, 16)
+	for i := range loginEntries {
+		loginEntries[i] = `{"sirketAdi":"İHLAS HABER AJANSI A.Ş.","sgkSicil":"2.6031.01.03","isyeriKodu":"x","kullaniciAdi":"u","isyeriSifresi":"p","token":"02bf0810-6d0e-4197-ad80-0dcb7fe5b962"}`
+	}
+	loginSuccess := "[" + strings.Join(loginEntries, ",") + "]"
+	wsLogin := `{"response":` + respEnv + `,"loginSuccess":` + loginSuccess + `,"loginFailed":[]}`
+
+	medium := func() string {
+		entries := make([]string, 4)
+		for i := range entries {
+			entries[i] = `{"sirketAdi":"İHLAS","sgkSicil":"2.6031","note":"` + strings.Repeat("y", 80) + `"}`
+		}
+		return "[" + strings.Join(entries, ",") + "]"
+	}
+	api := `{"wsLogin":` + wsLogin +
+		`,"raporAramaTarihile":{"response":` + medium() + `,"failedResponses":[],"noReports":[],"Reports":[]}` +
+		`,"raporOnay":{"response":` + medium() + `,"confirmedReports":[],"reportsNotConfirmed":[]}` +
+		`,"raporOkunduKapat":{"response":` + medium() + `,"reportsNotClosed":[]}` + `}`
+
+	t.Logf("api size: %d (threshold %d)  wsLogin size: %d", len(api), Threshold, len(wsLogin))
+
+	msg := []byte(`{"constants":{"api":` + api + `,"urls":{}}}`)
+
+	packed, err := s.Pack(msg)
+	if err != nil {
+		t.Fatalf("Pack: %v", err)
+	}
+	apiAfter := gjson.GetBytes(packed, "constants.api")
+	t.Logf("after Pack: api isBlobRef=%v", IsBlobRef(apiAfter))
+
+	resolved, err := s.ResolveAll(packed)
+	if err != nil {
+		t.Fatalf("ResolveAll: %v", err)
+	}
+
+	// Scan for any surviving BlobRef envelope.
+	survRef, survPath := findAnyBlobRef(resolved, "")
+	if survRef != "" {
+		t.Fatalf("NESTED BLOBREF SURVIVED RESOLVEALL — bug reproduced!\n"+
+			"surviving ref: %s\nsurviving path: %s\n", survRef, survPath)
+	}
+	respCheck := gjson.GetBytes(resolved, "constants.api.wsLogin.response")
+	if !respCheck.IsArray() {
+		t.Fatalf("expected resolved response to be an array, got: %s", respCheck.Raw[:200])
+	}
+}
+
+func findAnyBlobRef(data []byte, prefix string) (string, string) {
+	if !gjson.ValidBytes(data) {
+		return "", ""
+	}
+	return scan(gjson.ParseBytes(data), prefix)
+}
+func scan(n gjson.Result, prefix string) (string, string) {
+	if IsBlobRef(n) {
+		return gjson.Get(n.Raw, "__ref").String(), prefix
+	}
+	if n.Type != gjson.JSON {
+		return "", ""
+	}
+	var foundRef, foundPath string
+	if strings.HasPrefix(n.Raw, "{") {
+		n.ForEach(func(k, v gjson.Result) bool {
+			p := k.String()
+			if prefix != "" {
+				p = prefix + "." + p
+			}
+			if r, pp := scan(v, p); r != "" {
+				foundRef, foundPath = r, pp
+				return false
+			}
+			return true
+		})
+		return foundRef, foundPath
+	}
+	if strings.HasPrefix(n.Raw, "[") {
+		i := 0
+		n.ForEach(func(_, v gjson.Result) bool {
+			p := prefix
+			if p != "" {
+				p += "."
+			}
+			p += string(rune('0'+i))
+			i++
+			if r, pp := scan(v, p); r != "" {
+				foundRef, foundPath = r, pp
+				return false
+			}
+			return true
+		})
+	}
+	return foundRef, foundPath
+}


### PR DESCRIPTION
## Summary

`runtime/lmo/store.go:resolveValue` now recurses into the resolved blob bytes so nested BlobRef envelopes (left by Pack's `extractObject !modified` whole-pack branch) are also unwrapped. Without this the inner envelope surfaces to user code as a stub object and crashes downstream.

## Customer bug

Reproduced exactly by the new `runtime/lmo/store_test.go::TestNestedBlobRef_SurvivesResolveAll`. When an outer container (e.g. \`msg.constants.api\`) crosses 4 KB while no direct child does, the whole container gets packed as one blob. The blob bytes include any pre-existing inner BlobRef envelopes. \`ResolveAll\` unwraps the outer but not the inner. Test asserts no envelope survives.

## Test plan

- [x] \`go test ./runtime/lmo/...\` passes (existing + new regression test).
- [x] Same-semantics fix: callers already expect fully-resolved data.
- [x] No behavior change for healthy payloads — recursion is a no-op when resolved bytes have no nested envelopes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)