### PR TITLE
lmo: retry transient share errors on Windows + dedup-recover from lost rename race

### DIFF
--- a/runtime/lmo/atomic_windows_test.go
+++ b/runtime/lmo/atomic_windows_test.go
@@ -1,0 +1,128 @@
+//go:build windows
+
+package lmo
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// Deterministic Windows-only repros for the share-mode race that
+// renameAtomic / readFile defend against. Plain os.Rename / os.ReadFile
+// fail immediately under these conditions; the retried variants must
+// succeed once the holder releases mid-backoff.
+
+// openExclusiveRead opens a file with dwShareMode = 0 so that any
+// other CreateFile (including the one os.Rename / os.ReadFile issue
+// internally) returns ERROR_SHARING_VIOLATION until this handle closes.
+func openExclusiveRead(t *testing.T, path string) syscall.Handle {
+	t.Helper()
+	p, err := syscall.UTF16PtrFromString(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h, err := syscall.CreateFile(
+		p,
+		syscall.GENERIC_READ,
+		0, // no sharing — blocks all other opens
+		nil,
+		syscall.OPEN_EXISTING,
+		syscall.FILE_ATTRIBUTE_NORMAL,
+		0,
+	)
+	if err != nil {
+		t.Fatalf("CreateFile %s exclusive: %v", path, err)
+	}
+	return h
+}
+
+func TestRenameAtomic_RetriesPastSharingViolation(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	dst := filepath.Join(dir, "dst")
+	if err := os.WriteFile(src, []byte("new"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dst, []byte("old"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	holder := openExclusiveRead(t, dst)
+
+	// Sanity: plain os.Rename fails immediately while holder is open.
+	if err := os.Rename(src, dst); err == nil {
+		syscall.CloseHandle(holder)
+		t.Fatal("baseline check failed: os.Rename should reject under exclusive holder")
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- renameAtomic(src, dst)
+	}()
+
+	// Let renameAtomic burn through a few backoff cycles before releasing.
+	time.Sleep(2 * time.Millisecond)
+	syscall.CloseHandle(holder)
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("renameAtomic should retry past share violation: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("renameAtomic blocked past expected retry window")
+	}
+
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "new" {
+		t.Fatalf("dst content = %q, want %q", got, "new")
+	}
+}
+
+func TestReadFile_RetriesPastSharingViolation(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "blob")
+	want := []byte("payload")
+	if err := os.WriteFile(p, want, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	holder := openExclusiveRead(t, p)
+
+	// Sanity: plain os.ReadFile fails immediately while holder is open.
+	if _, err := os.ReadFile(p); err == nil {
+		syscall.CloseHandle(holder)
+		t.Fatal("baseline check failed: os.ReadFile should reject under exclusive holder")
+	}
+
+	type result struct {
+		data []byte
+		err  error
+	}
+	done := make(chan result, 1)
+	go func() {
+		data, err := readFile(p)
+		done <- result{data: data, err: err}
+	}()
+
+	time.Sleep(2 * time.Millisecond)
+	syscall.CloseHandle(holder)
+
+	select {
+	case r := <-done:
+		if r.err != nil {
+			t.Fatalf("readFile should retry past share violation: %v", r.err)
+		}
+		if string(r.data) != string(want) {
+			t.Fatalf("readFile content = %q, want %q", r.data, want)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("readFile blocked past expected retry window")
+	}
+}

--- a/runtime/lmo/store.go
+++ b/runtime/lmo/store.go
@@ -93,7 +93,7 @@ func (s *Store) GetBlob(ref, relPath string) ([]byte, error) {
 	}
 	p := filepath.Join(s.configDir, "store", relPath, "blobs", h[:2], h[2:])
 
-	compressed, err := os.ReadFile(p)
+	compressed, err := readFile(p)
 	if err != nil {
 		return nil, fmt.Errorf("lmo: read blob %s: %w", ref, err)
 	}
@@ -258,7 +258,16 @@ func (s *Store) PutBlob(data []byte) (string, error) {
 		os.Remove(tmpPath)
 		return "", fmt.Errorf("lmo: close tmp blob: %w", err)
 	}
-	if err := os.Rename(tmpPath, p); err != nil {
+	if err := renameAtomic(tmpPath, p); err != nil {
+		// On Windows a concurrent reader holding the destination open without
+		// FILE_SHARE_DELETE causes rename to fail with Access denied even
+		// after the share-error retry exhausts. If another writer in the
+		// meantime produced a valid file at the destination (content-addressed,
+		// so same hash → same bytes), treat that as a dedup win.
+		if info, statErr := os.Stat(p); statErr == nil && info.Size() > 0 {
+			os.Remove(tmpPath)
+			return ref, nil
+		}
 		os.Remove(tmpPath)
 		return "", fmt.Errorf("lmo: rename blob: %w", err)
 	}

--- a/runtime/lmo/store_unix.go
+++ b/runtime/lmo/store_unix.go
@@ -1,0 +1,10 @@
+//go:build !windows
+
+package lmo
+
+import "os"
+
+// POSIX rename(2) is atomic and readers don't interfere — no retry needed.
+func renameAtomic(oldPath, newPath string) error { return os.Rename(oldPath, newPath) }
+
+func readFile(p string) ([]byte, error) { return os.ReadFile(p) }

--- a/runtime/lmo/store_windows.go
+++ b/runtime/lmo/store_windows.go
@@ -1,0 +1,84 @@
+//go:build windows
+
+package lmo
+
+import (
+	"errors"
+	"os"
+	"syscall"
+	"time"
+)
+
+// On Windows, MoveFileEx and CreateFile interact through share modes. Go's
+// os.Open opens with FILE_SHARE_READ | FILE_SHARE_WRITE — but NOT
+// FILE_SHARE_DELETE — so a concurrent reader prevents the writer's
+// MoveFileEx (Access is denied), and a rename-in-flight briefly blocks new
+// opens (Sharing violation). POSIX rename(2) has no such races.
+//
+// We treat these as transient: retry with short exponential backoff. Real
+// permission failures (a file actually not readable) still surface because
+// they don't clear on retry — the loop just adds a small startup cost.
+const (
+	maxFileRetries     = 16
+	initialFileBackoff = 100 * time.Microsecond
+	maxFileBackoff     = 8 * time.Millisecond
+)
+
+// Windows error codes not exported as named constants by the syscall pkg.
+// Defined inline rather than pulling in golang.org/x/sys/windows.
+const (
+	errSharingViolation syscall.Errno = 32 // ERROR_SHARING_VIOLATION
+	errLockViolation    syscall.Errno = 33 // ERROR_LOCK_VIOLATION
+)
+
+func isTransientShareErr(err error) bool {
+	var errno syscall.Errno
+	if !errors.As(err, &errno) {
+		return false
+	}
+	switch errno {
+	case errSharingViolation, errLockViolation, syscall.ERROR_ACCESS_DENIED:
+		return true
+	}
+	return false
+}
+
+func renameAtomic(oldPath, newPath string) error {
+	backoff := initialFileBackoff
+	var lastErr error
+	for i := 0; i < maxFileRetries; i++ {
+		err := os.Rename(oldPath, newPath)
+		if err == nil {
+			return nil
+		}
+		if !isTransientShareErr(err) {
+			return err
+		}
+		lastErr = err
+		time.Sleep(backoff)
+		if backoff < maxFileBackoff {
+			backoff *= 2
+		}
+	}
+	return lastErr
+}
+
+func readFile(p string) ([]byte, error) {
+	backoff := initialFileBackoff
+	var lastErr error
+	for i := 0; i < maxFileRetries; i++ {
+		data, err := os.ReadFile(p)
+		if err == nil {
+			return data, nil
+		}
+		if !isTransientShareErr(err) {
+			return nil, err
+		}
+		lastErr = err
+		time.Sleep(backoff)
+		if backoff < maxFileBackoff {
+			backoff *= 2
+		}
+	}
+	return nil, lastErr
+}


### PR DESCRIPTION
## Summary
- Adds `renameAtomic` / `readFile` retry helpers around `os.Rename` / `os.ReadFile` (build-tagged windows; pass-through on unix) to absorb transient `ERROR_ACCESS_DENIED` / `ERROR_SHARING_VIOLATION` from the `MoveFileEx` ↔ `CreateFile` share-mode interaction. Mirrors deskbot PR #2586.
- If retries exhaust but a valid blob already exists at the destination, treat it as a dedup win (content-addressed: same hash → same bytes) rather than failing the writer.
- Adds a deterministic Windows-only test (`atomic_windows_test.go`) that holds the destination via Win32 `CreateFileW` with `dwShareMode=0`, runs `renameAtomic` / `readFile` in a worker goroutine, and verifies retry-then-success once the holder releases mid-backoff.

## Why this only happens on Windows
Go's `os.Open` opens files with `FILE_SHARE_READ | FILE_SHARE_WRITE` (no `FILE_SHARE_DELETE`), so a concurrent reader blocks `MoveFileEx` with `ERROR_ACCESS_DENIED`, and a rename-in-flight blocks new opens with `ERROR_SHARING_VIOLATION`. POSIX `rename(2)` has neither race.

## Test plan
- [x] `go test ./runtime/lmo/...` passes (Windows)
- [x] New Win-only tests fail deterministically with no-retry stub (`Access is denied` / `being used by another process`); pass with retry layer
- [x] Cross-compile `GOOS=linux` / `GOOS=darwin` builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)