### PR TITLE
runtime: Toolkit/SkillProvider SDK + OptVariable+enum multi-select

### DIFF
--- a/docs/toolkit-skill-provider.md
+++ b/docs/toolkit-skill-provider.md
@@ -1,0 +1,557 @@
+# Toolkit & Skill Providers
+
+*Last updated: May 15, 2026*
+
+Two opt-in SDK capabilities that let any Robomotion package expose AI-agent functionality without the agent package (Hermes, ADK, …) needing per-package knowledge. **ToolkitProvider** bundles multiple tools under a single node; **SkillProvider** ships markdown guidance that the agent appends to its system prompt. They are independent — a node can implement either, both, or neither.
+
+This document covers the Go SDK. The Python SDK has the same shape — see `robomotion-python/docs/toolkit-skill-provider.md`.
+
+---
+
+## Table of Contents
+
+1. [Why these exist](#1-why-these-exist)
+2. [The mental model](#2-the-mental-model)
+3. [ToolkitProvider](#3-toolkitprovider)
+4. [SkillProvider](#4-skillprovider)
+5. [Wire protocol — how tool calls flow](#5-wire-protocol--how-tool-calls-flow)
+6. [The OptVariable+enum multi-select pattern](#6-the-optvariableenum-multi-select-pattern)
+7. [Spec emission reference](#7-spec-emission-reference)
+8. [End-to-end example: Agent Teams Toolkit](#8-end-to-end-example-agent-teams-toolkit)
+9. [When to use single Tool vs Toolkit](#9-when-to-use-single-tool-vs-toolkit)
+10. [Testing](#10-testing)
+11. [Files reference](#11-files-reference)
+
+---
+
+## 1. Why these exist
+
+Before these capabilities, exposing a *bundle* of related tools to an AI agent required either:
+
+- Wiring **N individual Tool In nodes** on the canvas (a `Receive → Function → Hermes (8 × Tool In)` mess), or
+- Building a **per-package branch inside every agent package** (`if node_type == 'Robomotion.AgentTeams.Toolkit': ...`) — leaks domain knowledge into Hermes/ADK and breaks the moment a new agent runtime ships.
+
+Behavioral guidance had a similar problem: workspace-level Skills (in the Designer's Skills tab) had to be toggled separately, and the rules describing how a package's tools should be used lived in a different file than the tools themselves.
+
+ToolkitProvider and SkillProvider solve both at the SDK level. Any agent package that reads pspec via `Runtime.get_port_connections` can consume them generically — Hermes, ADK, and any future runtime work the same way without changes.
+
+---
+
+## 2. The mental model
+
+| Question | Interface | pspec key | Agent-side consumer |
+|---|---|---|---|
+| **What** can the agent do? | `ToolkitProvider` | `tools[]` | tool registry — one callable per ToolDef |
+| **How** should the agent behave? | `SkillProvider` | `skill` | system message — appended to the prompt |
+| (Legacy: one tool only) | `runtime.Tool` marker + tag | `tool` | tool registry — one callable per node |
+
+Two independent walks of the same connected-nodes list. One harvests callables, the other harvests markdown. The agent doesn't need to know which interface a node implements.
+
+---
+
+## 3. ToolkitProvider
+
+### Marker
+
+```go
+type Toolkit struct{}
+```
+
+Embed it in your node struct. The spec generator detects the embedded type by name (`Toolkit`) and switches into multi-tool emission.
+
+### Interface
+
+```go
+type ToolDef struct {
+    Name        string                 `json:"name"`
+    Description string                 `json:"description"`
+    Schema      map[string]interface{} `json:"schema"`
+}
+
+type ToolkitProvider interface {
+    Tools() []ToolDef
+}
+```
+
+`Tools()` is called once at package build time during `go run main.go -s` (spec generation). The list is **frozen at build** — flow-author scoping at runtime happens through an `OptVariable` (see §6), not by re-evaluating `Tools()` per turn.
+
+`Schema` is JSON Schema. Build it inline, load it from `//go:embed`, generate it from struct types — any approach that yields a `map[string]interface{}` works.
+
+### Helpers
+
+In your `OnMessage`, the agent invocation arrives with a tool-name discriminator and parameters dict:
+
+```go
+func (n *MyToolkit) OnMessage(ctx message.Context) error {
+    if !runtime.IsToolRequest(ctx) {
+        return nil
+    }
+    name   := runtime.ToolName(ctx)
+    params := runtime.ToolParameters(ctx)
+
+    switch name {
+    case "send_message":
+        return n.sendMessage(ctx, params)
+    case "comment_on_ticket":
+        return n.commentOnTicket(ctx, params)
+    // ...
+    }
+    return runtime.ToolResponse(ctx, "error", nil, "unknown tool: "+name)
+}
+```
+
+Each handler returns via `runtime.ToolResponse(ctx, status, data, errMsg)`. The SDK's `ToolInterceptor` is responsible for routing the response back to the calling agent over Robomotion's emit_input bus — see §5.
+
+### Minimal example
+
+```go
+type SearchToolkit struct {
+    runtime.Node    `spec:"id=Acme.Search.Toolkit,name=Search Toolkit,icon=mdiMagnify,color=#3b82f6"`
+    runtime.Toolkit `toolkit:""`
+}
+
+func (n *SearchToolkit) OnCreate() error                   { return nil }
+func (n *SearchToolkit) OnClose() error                    { return nil }
+func (n *SearchToolkit) OnMessage(ctx message.Context) error {
+    if !runtime.IsToolRequest(ctx) {
+        return nil
+    }
+    params := runtime.ToolParameters(ctx)
+    switch runtime.ToolName(ctx) {
+    case "web_search":
+        result, err := webSearch(params["query"].(string))
+        if err != nil {
+            return runtime.ToolResponse(ctx, "error", nil, err.Error())
+        }
+        return runtime.ToolResponse(ctx, "success", map[string]interface{}{"results": result}, "")
+    case "image_search":
+        // ...
+    }
+    return runtime.ToolResponse(ctx, "error", nil, "unknown tool")
+}
+
+func (n *SearchToolkit) Tools() []runtime.ToolDef {
+    return []runtime.ToolDef{
+        {
+            Name:        "web_search",
+            Description: "Search the web. Returns the top 10 hits as {title, url, snippet}.",
+            Schema: map[string]interface{}{
+                "type": "object",
+                "properties": map[string]interface{}{
+                    "query": map[string]interface{}{
+                        "type":        "string",
+                        "description": "Free-text search query.",
+                    },
+                },
+                "required": []string{"query"},
+            },
+        },
+        {
+            Name:        "image_search",
+            Description: "Search for images. Returns top 20 image URLs with alt text.",
+            Schema: map[string]interface{}{
+                "type": "object",
+                "properties": map[string]interface{}{
+                    "query": map[string]interface{}{"type": "string"},
+                },
+                "required": []string{"query"},
+            },
+        },
+    }
+}
+```
+
+Register the toolkit in your `main.go` just like any other node:
+
+```go
+runtime.RegisterNodes(&SearchToolkit{})
+```
+
+The LLM now sees two callable tools (`web_search`, `image_search`) — but only one node on the canvas.
+
+---
+
+## 4. SkillProvider
+
+### Interface
+
+```go
+type SkillProvider interface {
+    Skill() string
+}
+```
+
+Returns markdown. The spec generator emits it as the node's `skill` field. The consuming agent appends it to the system prompt when the node is wired to its tools port.
+
+Conceptually the in-tree equivalent of MCP's `prompts/get` — the behavioral contract travels with the tools instead of living in a separate skill store.
+
+### Independence from Toolkit
+
+SkillProvider is **not** part of ToolkitProvider. A node can:
+
+- Implement both (the common case — a toolkit + its AGENT.md)
+- Implement only `Toolkit` (raw tools, no extra guidance — the function descriptions are enough)
+- Implement only `Skill` (no callable tools, just system-prompt extension)
+- Implement neither (a regular flow node — unchanged behavior)
+
+### Three patterns
+
+#### Pattern A — Skill alongside a Toolkit
+
+The canonical pairing. The toolkit's AGENT.md explains when to call each tool, the etiquette, the gotchas:
+
+```go
+//go:embed AGENT.md
+var agentMD string
+
+type Toolkit struct {
+    runtime.Node    `spec:"id=Robomotion.AgentTeams.Toolkit,..."`
+    runtime.Toolkit `toolkit:""`
+}
+
+func (n *Toolkit) Tools() []runtime.ToolDef { /* 8 tools */ }
+func (n *Toolkit) Skill() string            { return agentMD }
+```
+
+`AGENT.md` excerpt:
+
+```markdown
+# Agent Teams operating contract
+
+- For chat (mention/DM): reply with `send_message`. Be useful in one
+  message when you can.
+- For tickets: comment with `comment_on_ticket`. Only call
+  `update_ticket(status="closed")` when work is complete AND verified.
+- Use `request_approval(question, options?)` for any irreversible
+  action — status transition to closed, external email, large data
+  deletion, budget spend.
+- Do not @-mention the original sender just to acknowledge. Silence
+  ends a conversation cleanly.
+```
+
+#### Pattern B — Skill alongside a single Tool
+
+A `runtime.Tool`-tagged node ships its own usage convention:
+
+```go
+type CreateLinearIssue struct {
+    runtime.Node `spec:"id=Linear.CreateIssue,..."`
+    runtime.Tool `tool:"name=linear_create_issue,description=Create a Linear issue"`
+}
+
+func (n *CreateLinearIssue) Skill() string {
+    return `When creating Linear issues:
+- Always set team_id explicitly. Never default to "engineering".
+- Label "bug" is for confirmed defects only; user reports use "user-feedback".
+- Priority: P2 for production issues, P3 for everything else.
+- Title must start with a verb: "Fix...", "Add...", "Investigate...".`
+}
+```
+
+The LLM gets the tool **and** the team's specific conventions. The convention used to live in someone's head or a separate doc; now it ships with the node.
+
+#### Pattern C — Skill with no tools at all
+
+A "context node" wired to the tools port purely to inject guidance:
+
+```go
+type BrandVoiceContext struct {
+    runtime.Node `spec:"id=Acme.BrandVoice,name=Brand Voice,icon=mdiBullhorn,color=#10b981"`
+}
+
+//go:embed brand-voice.md
+var brandVoiceMD string
+
+func (n *BrandVoiceContext) Skill() string { return brandVoiceMD }
+func (n *BrandVoiceContext) OnCreate() error                   { return nil }
+func (n *BrandVoiceContext) OnClose() error                    { return nil }
+func (n *BrandVoiceContext) OnMessage(_ message.Context) error { return nil }
+```
+
+`brand-voice.md`:
+
+```markdown
+# Acme Brand Voice
+
+When writing customer-facing copy:
+- Use second person ("you can…") not first ("we can…")
+- Never exclamation marks. Period.
+- "Acme" is always capitalized. Never "ACME" or "acme".
+- Don't use the words "easy" or "simple" — they're patronizing.
+```
+
+Wire this to a HermesAgent. The LLM now writes copy in Acme's voice on every turn even though no callable tool was added. Pure system-message extension by canvas wiring.
+
+---
+
+## 5. Wire protocol — how tool calls flow
+
+Agents call toolkit tools over Robomotion's normal `emit_input` message bus. **No HTTP, no MCP subprocess, no new transport** — the same gRPC + NATS path every other inter-node message uses.
+
+```
+1. Agent's LLM emits a tool call:    web_search(query="cats")
+2. Agent runtime serializes:
+       message.Context with
+         __message_type__   = "tool_request"
+         __tool_name__      = "web_search"
+         __parameters__     = {"query": "cats"}
+         __tool_caller_id__ = "<uuid>"
+         __agent_node_id__  = "<agent guid>"
+3. Event.emit_input(toolkitNodeGuid, ctx)
+4. Toolkit's OnMessage fires; ToolInterceptor recognizes IsToolRequest(ctx).
+5. Handler runs; calls runtime.ToolResponse(ctx, "success", data, "")
+6. ToolResponse emits a __message_type__="tool_response" back to
+   __agent_node_id__ via Event.emit_input.
+7. Agent's on_message catches the tool_response at the top, looks up
+   the caller_id, unblocks the waiting handler with the result.
+```
+
+This is the same protocol single-Tool nodes have always spoken (see `runtime/tool_response.go`). The only difference for a Toolkit is the `__tool_name__` discriminator — which is what lets one node guid host N tools.
+
+### Reading helpers
+
+```go
+runtime.IsToolRequest(ctx)         // bool — am I being called as a tool?
+runtime.ToolName(ctx)              // string — which one?
+runtime.ToolParameters(ctx)        // map[string]interface{} — the args
+runtime.ToolResponse(ctx, status, data, errMsg)   // reply
+```
+
+### Auto-response from ToolInterceptor
+
+If your `OnMessage` returns without calling `ToolResponse` explicitly, the `ToolInterceptor` collects every OutVariable's value and auto-responds with a synthesized success. This is fine for trivial passthrough cases. **For toolkits, always call `ToolResponse` explicitly** — it gives you control over the success/error split and the response payload shape.
+
+---
+
+## 6. The OptVariable+enum multi-select pattern
+
+A toolkit usually wants flow authors to choose **which** tools to expose to the agent (security + LLM-attention budget). The SDK supports this with a Catch-style checkbox grid:
+
+```go
+type Toolkit struct {
+    runtime.Node    `spec:"id=...,..."`
+    runtime.Toolkit `toolkit:""`
+
+    OptEnabled runtime.OptVariable[[]string] `spec:"
+        title=Enabled Tools,
+        type=array,
+        scope=Custom,
+        name=,
+        customScope,
+        enum=web_search|image_search|news_search,
+        enumNames=Web Search|Image Search|News Search,
+        description=Pick which tools this toolkit exposes. Empty = all."`
+}
+```
+
+What this produces:
+
+- **Spec** — `type=array`, `multiple=true`, `items.enum=[...]`, `items.enumNames=[...]`, `formData=[]` default
+- **Designer UISchema** — `ui:field=multiSelectCheckbox` (the widget added in `robomotion-new-designer`)
+- **Runtime** — the user-selected names land as a `[]string` on `OptEnabled`. Agent-side discovery reads it and registers only the selected tools.
+
+In the agent-side discovery branch (Hermes example):
+
+```python
+enabled = read_optvar_string_list(inner, 'optEnabled')
+for tdef in tools_array:
+    if enabled and tdef['name'] not in enabled:
+        continue
+    register(tdef)
+```
+
+The convention is: **empty list = expose all tools**. Users opt out, they don't opt in. This makes a freshly-dropped toolkit useful by default.
+
+---
+
+## 7. Spec emission reference
+
+What lands in the generated pspec JSON for each shape:
+
+### Toolkit + Skill
+
+```json
+{
+  "id": "Acme.Search.Toolkit",
+  "name": "Search Toolkit",
+  "icon": "...",
+  "color": "#3b82f6",
+  "tools": [
+    {
+      "name": "web_search",
+      "description": "Search the web...",
+      "schema": { "type": "object", "properties": { ... }, "required": [...] }
+    },
+    { "name": "image_search", ... }
+  ],
+  "skill": "# How to use Acme Search\n\nFor general queries...",
+  "properties": [ ... ]
+}
+```
+
+### Single Tool (legacy, unchanged)
+
+```json
+{
+  "id": "Linear.CreateIssue",
+  "tool": { "name": "linear_create_issue", "description": "Create a Linear issue" }
+}
+```
+
+A node should emit **either** `tool` (singular) **or** `tools[]` (plural), never both. The spec generator does not enforce this, but consuming agents may pick whichever they see first; mixing them is a bug.
+
+### Skill-only
+
+```json
+{
+  "id": "Acme.BrandVoice",
+  "skill": "# Acme Brand Voice\n\nWhen writing customer-facing copy..."
+}
+```
+
+No `tool` or `tools` keys. The agent's `connect_tools` walk skips this node (no callable to register); its `collect_node_skills` walk picks it up.
+
+---
+
+## 8. End-to-end example: Agent Teams Toolkit
+
+The reference implementation lives in `packages-main/src/robomotion-agent-teams/v1/agents/toolkit.go`. Highlights:
+
+```go
+//go:embed AGENT.md
+var agentMD string
+
+type Toolkit struct {
+    runtime.Node    `spec:"id=Robomotion.AgentTeams.Agents.Toolkit,name=Agent Teams Toolkit,icon=agentTeamsIcon,color=#f97316"`
+    runtime.Toolkit `toolkit:""`
+
+    OptEnabled runtime.OptVariable[[]string] `spec:"...,enum=send_message|comment_on_ticket|update_ticket|get_ticket|list_channels|list_channel_members|open_dm|request_approval,..."`
+    OptAutoAck runtime.OptVariable[bool]     `spec:"title=Auto-Ack Inbox,type=boolean,..."`
+}
+
+func (n *Toolkit) Tools() []runtime.ToolDef {
+    return []runtime.ToolDef{
+        {Name: "send_message",      ...},
+        {Name: "comment_on_ticket", ...},
+        {Name: "update_ticket",     ...},
+        {Name: "get_ticket",        ...},
+        {Name: "list_channels",     ...},
+        {Name: "list_channel_members", ...},
+        {Name: "open_dm",           ...},
+        {Name: "request_approval",  ...},
+    }
+}
+
+func (n *Toolkit) Skill() string { return agentMD }
+
+func (n *Toolkit) OnMessage(ctx message.Context) error {
+    if !runtime.IsToolRequest(ctx) { return nil }
+    tool := runtime.ToolName(ctx)
+    params := runtime.ToolParameters(ctx)
+
+    if !n.toolEnabled(ctx, tool) {
+        return runtime.ToolResponse(ctx, "error", nil, "tool '"+tool+"' is not enabled")
+    }
+
+    switch tool {
+    case "send_message":      // POST /v1/teams.agents.messages.post
+    case "comment_on_ticket": // POST /v1/teams.agents.tickets.comment
+    // ... 6 more
+    }
+}
+```
+
+What this delivers to the flow author:
+
+- **One node** wired to Hermes/ADK's tools port instead of 8 individual nodes
+- **Checkbox grid** in the Designer for narrowing the exposed surface
+- **AGENT.md guidance** automatically merged into the agent's system prompt
+- **Inbox auto-ack** on first reply tool (`OptAutoAck`)
+- **Cross-agent** — the same toolkit works against Hermes and ADK with no per-agent code
+
+---
+
+## 9. When to use single Tool vs Toolkit
+
+Use **single `runtime.Tool`** when:
+
+- The node has one obvious action and the flow author wants it visibly on the canvas (e.g., `Linear.CreateIssue`, `Stripe.RefundPayment`)
+- Auditability matters — each tool gets its own node, each call leaves its own trace pulse on the canvas
+- Different tools have very different parameter shapes that wouldn't benefit from sharing context
+
+Use **`runtime.Toolkit`** when:
+
+- 3+ related actions share context (auth, env, conventions) and the flow author shouldn't have to wire them individually
+- The agent should pick from a menu based on the situation (chat vs ticket, etc.) — bundling lets the LLM see them all together
+- You want a checkbox-grid surface filter
+
+Both shapes use the same wire protocol — you can migrate one to the other later without breaking consumers.
+
+---
+
+## 10. Testing
+
+The SDK ships tests at `runtime/tool_test.go` and `runtime/spec_test.go`:
+
+```bash
+cd robomotion-go
+go test ./runtime/ -run 'TestTool|TestSkill|TestSpec' -v
+```
+
+Patterns for testing your own toolkit:
+
+```go
+func TestMyToolkit_Tools(t *testing.T) {
+    tk := &MyToolkit{}
+    tools := tk.Tools()
+    if len(tools) != 3 {
+        t.Fatalf("expected 3 tools, got %d", len(tools))
+    }
+    for _, td := range tools {
+        if td.Name == "" || td.Description == "" || td.Schema == nil {
+            t.Errorf("incomplete ToolDef: %+v", td)
+        }
+    }
+}
+
+func TestMyToolkit_Dispatch(t *testing.T) {
+    ctx := message.NewContext([]byte(`{
+        "__message_type__": "tool_request",
+        "__tool_name__":    "web_search",
+        "__parameters__":   {"query": "cats"}
+    }`))
+    if !runtime.IsToolRequest(ctx) {
+        t.Fatal("ctx should be a tool request")
+    }
+    if runtime.ToolName(ctx) != "web_search" {
+        t.Fatal("wrong tool name")
+    }
+    if runtime.ToolParameters(ctx)["query"] != "cats" {
+        t.Fatal("wrong params")
+    }
+}
+```
+
+For full integration testing including spec emission, see the patterns in `runtime/spec_test.go` — it captures `generateSpecFile`'s stdout, parses the JSON, and makes structured assertions about pspec shape.
+
+---
+
+## 11. Files reference
+
+| File | What |
+|---|---|
+| `runtime/tool.go` | `Tool`, `Toolkit` markers; `ToolDef`, `ToolkitProvider`, `SkillProvider` |
+| `runtime/tool_response.go` | `IsToolRequest`, `ToolName`, `ToolParameters`, `ToolResponse` |
+| `runtime/tool_interceptor.go` | Auto-wraps `OnMessage` to recognize tool requests |
+| `runtime/spec.go` | Spec generator — emits `tool`, `tools[]`, `skill` plus the OptVariable+enum multi-select shape |
+| `runtime/tool_test.go` | Unit tests for helpers + interface compliance |
+| `runtime/spec_test.go` | Spec emission tests with stdout capture |
+
+---
+
+## See also
+
+- **Python equivalent** — `robomotion-python/docs/toolkit-skill-provider.md`
+- **First production user** — `packages-main/src/robomotion-agent-teams/v1/agents/toolkit.go`
+- **Agent-side discovery** — `packages-main/src/hermes-agent/nodes/simulation/tool_simulation.py` (the `'tools'`/`'tool'`/`skill` branches in `connect_tools` + `collect_node_skills`) and the matching path in `packages-main/src/adk-agent/`
+- **Designer widget** — `robomotion-new-designer/src/components/ui/jsonSchemaForm/components/multiSelectCheckbox/`

--- a/runtime/spec.go
+++ b/runtime/spec.go
@@ -26,7 +26,18 @@ type NodeSpec struct {
 	InFilters   *string     `json:"inFilters,omitempty"`
 	Properties  []Property  `json:"properties"`
 	CustomPorts interface{} `json:"customPorts,omitempty"`
-	Tool        interface{} `json:"tool,omitempty"`
+	// Tool is the single-tool descriptor for nodes embedding runtime.Tool.
+	Tool interface{} `json:"tool,omitempty"`
+	// Tools is the multi-tool descriptor for nodes embedding runtime.Toolkit
+	// and implementing ToolkitProvider. Each entry is one tool routed to
+	// this node's guid; the agent passes __tool_name__ on the wire to
+	// discriminate. Mutually exclusive with Tool in practice — a node uses
+	// one shape or the other.
+	Tools []ToolDef `json:"tools,omitempty"`
+	// Skill is the optional system-message addendum the consuming agent
+	// appends when this node is wired to its tools port. Populated from
+	// SkillProvider.Skill().
+	Skill string `json:"skill,omitempty"`
 }
 
 type Property struct {
@@ -111,13 +122,28 @@ func generateSpecFile(pluginName, version string) {
 		if toolField, hasToolField := t.FieldByName("Tool"); hasToolField {
 			toolTag := toolField.Tag.Get("tool")
 			toolParts := parseSpec(toolTag)
-			
+
 			if toolName := toolParts["name"]; toolName != "" {
 				spec.Tool = map[string]string{
 					"name":        toolName,
 					"description": toolParts["description"],
 				}
 			}
+		}
+
+		// Check if node embeds Toolkit and implements ToolkitProvider /
+		// SkillProvider. Spec emission instantiates a zero value via
+		// reflect.New (same shape NodeFactory uses) so the methods are
+		// available on a pointer receiver — the conventional way Robomotion
+		// nodes define their handlers.
+		if _, hasToolkitField := t.FieldByName("Toolkit"); hasToolkitField {
+			instance := reflect.New(t).Interface()
+			if tp, ok := instance.(ToolkitProvider); ok {
+				spec.Tools = tp.Tools()
+			}
+		}
+		if instance, _ := reflect.New(t).Interface().(SkillProvider); instance != nil {
+			spec.Skill = instance.Skill()
 		}
 
 		// Look for custom port fields (fields of type Port)
@@ -220,6 +246,29 @@ func generateSpecFile(pluginName, version string) {
 						"scope": map[string]interface{}{"type": "string"},
 						"name":  map[string]interface{}{"properties": arrProps},
 					},
+				}
+
+			} else if isVar && isEnum && isOptVar {
+				// OptVariable + enum tag = checkbox-list multi-select. The
+				// Designer renders it via the multiSelectCheckbox widget;
+				// the runtime unmarshals the resulting array of strings
+				// into the OptVariable[[]string] field's name slot. This
+				// is the shape Catch-style tool filtering uses (see
+				// Toolkit.OptEnabled in agent-teams).
+				enumVals, enumNames := parseEnum(enum, fsMap["enumNames"], getVariableType(field, fsMap))
+				sProp.Enum = enumVals
+				sProp.EnumNames = enumNames
+				multiple := true
+				sProp.Multiple = &multiple
+				sProp.Type = "array"
+				itemType := strings.ToLower(getVariableType(field, fsMap))
+				if itemType == "array" {
+					itemType = "string"
+				}
+				sProp.Items = &map[string]interface{}{
+					"type":      itemType,
+					"enum":      enumVals,
+					"enumNames": enumNames,
 				}
 
 			} else if isVar {
@@ -368,6 +417,12 @@ func generateSpecFile(pluginName, version string) {
 					optProperty.UISchema[lowerFieldName] = map[string]string{"ui:field": format}
 				} else if isArray {
 					optProperty.UISchema[lowerFieldName] = map[string]string{"ui:field": "array"}
+					optProperty.FormData[lowerFieldName] = []interface{}{}
+				} else if isVar && isEnum && isOptVar {
+					// Multi-select OptVariable[[]string]: render as checkboxes,
+					// formData is a flat string array (no scope/name wrapper —
+					// the field has a fixed schema, not a variable reference).
+					optProperty.UISchema[lowerFieldName] = map[string]string{"ui:field": "multiSelectCheckbox"}
 					optProperty.FormData[lowerFieldName] = []interface{}{}
 				} else if isVar {
 					optProperty.FormData[lowerFieldName] = VarDataProperty{Scope: scope, Name: n}

--- a/runtime/spec_test.go
+++ b/runtime/spec_test.go
@@ -1,0 +1,281 @@
+package runtime
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/robomotionio/robomotion-go/message"
+)
+
+// These tests drive generateSpecFile against fixture node types and
+// assert the JSON it prints. The fixtures cover the three spec-emission
+// paths the toolkit work touches:
+//
+//   • runtime.Tool      → node.tool: {name, description}
+//   • runtime.Toolkit + ToolkitProvider.Tools() → node.tools: [...]
+//   • runtime.SkillProvider.Skill() → node.skill: "..."
+//   • OptVariable[[]string] + enum  → multi-select shape with
+//     items.enum/enumNames and ui:field=multiSelectCheckbox
+//
+// generateSpecFile prints to stdout. We pipe stdout through an os.Pipe
+// to capture the output, restore the original FD after, and unmarshal
+// the JSON to make structured assertions.
+
+// ---------------------------------------------------------------------------
+// Fixture node types
+// ---------------------------------------------------------------------------
+
+// fxToolkit exercises the multi-tool path. It embeds runtime.Toolkit and
+// implements ToolkitProvider + SkillProvider so the spec generator emits
+// `tools[]` and `skill`. The OptEnabled field uses OptVariable[[]string]
+// + enum to drive the multi-select checkbox path.
+type fxToolkit struct {
+	Node    `spec:"id=Test.Toolkit,name=Test Toolkit,icon=,color=#000"`
+	Toolkit `toolkit:""`
+
+	OptEnabled runtime_OptVariableStringSlice `spec:"title=Enabled,type=array,scope=Custom,name=,customScope,enum=a|b|c,enumNames=A|B|C"`
+}
+
+// runtime_OptVariableStringSlice exists because the test fixture cannot
+// inline `OptVariable[[]string]` as a struct field tag without pulling
+// the generic instantiation into the type definition. Aliasing keeps
+// the spec generator's reflection path happy (it inspects the type's
+// name prefix via `isGenericType`).
+type runtime_OptVariableStringSlice = OptVariable[[]string]
+
+func (n *fxToolkit) OnCreate() error                     { return nil }
+func (n *fxToolkit) OnMessage(_ message.Context) error   { return nil }
+func (n *fxToolkit) OnClose() error                      { return nil }
+func (n *fxToolkit) Tools() []ToolDef {
+	return []ToolDef{
+		{Name: "one", Description: "first", Schema: map[string]interface{}{"type": "object"}},
+		{Name: "two", Description: "second", Schema: map[string]interface{}{
+			"type":     "object",
+			"required": []interface{}{"x"},
+		}},
+	}
+}
+func (n *fxToolkit) Skill() string { return "use this toolkit wisely" }
+
+// fxSingleTool exercises the legacy single-Tool path so the test suite
+// also pins the back-compat behavior — `tool: {name, description}` must
+// still emit unchanged.
+type fxSingleTool struct {
+	Node `spec:"id=Test.SingleTool,name=Test Single,icon=,color=#000"`
+	Tool `tool:"name=do_thing,description=does a thing"`
+}
+
+func (n *fxSingleTool) OnCreate() error                   { return nil }
+func (n *fxSingleTool) OnMessage(_ message.Context) error { return nil }
+func (n *fxSingleTool) OnClose() error                    { return nil }
+
+// fxPlain has neither Tool nor Toolkit — its emitted spec must carry
+// neither `tool` nor `tools` nor `skill`.
+type fxPlain struct {
+	Node `spec:"id=Test.Plain,name=Test Plain,icon=,color=#000"`
+}
+
+func (n *fxPlain) OnCreate() error                   { return nil }
+func (n *fxPlain) OnMessage(_ message.Context) error { return nil }
+func (n *fxPlain) OnClose() error                    { return nil }
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// captureSpec registers `nodes` with the SDK's handler list, runs the
+// spec generator, captures the printed JSON, and unmarshals it. The
+// previous handlerList is restored on exit so concurrent test packages
+// remain isolated.
+func captureSpec(t *testing.T, nodes ...MessageHandler) map[string]interface{} {
+	t.Helper()
+
+	prev := handlerList
+	t.Cleanup(func() { handlerList = prev })
+	RegisterNodes(nodes...)
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	origStdout := os.Stdout
+	os.Stdout = w
+	defer func() { os.Stdout = origStdout }()
+
+	doneCh := make(chan []byte, 1)
+	go func() {
+		buf, _ := io.ReadAll(r)
+		doneCh <- buf
+	}()
+
+	generateSpecFile("test-plugin", "0.0.1")
+	w.Close()
+	raw := <-doneCh
+
+	var pspec map[string]interface{}
+	if err := json.Unmarshal(raw, &pspec); err != nil {
+		t.Fatalf("spec JSON decode failed (output=%q): %v", string(raw), err)
+	}
+	return pspec
+}
+
+func nodeByID(t *testing.T, pspec map[string]interface{}, id string) map[string]interface{} {
+	t.Helper()
+	nodes, ok := pspec["nodes"].([]interface{})
+	if !ok {
+		t.Fatalf("pspec[nodes] missing or wrong type: %T", pspec["nodes"])
+	}
+	for _, n := range nodes {
+		m, ok := n.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if m["id"] == id {
+			return m
+		}
+	}
+	t.Fatalf("node id=%q not found in pspec (got %d nodes)", id, len(nodes))
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+func TestSpec_ToolkitEmitsToolsAndSkill(t *testing.T) {
+	pspec := captureSpec(t, &fxToolkit{})
+	node := nodeByID(t, pspec, "Test.Toolkit")
+
+	tools, ok := node["tools"].([]interface{})
+	if !ok {
+		t.Fatalf("node.tools missing or wrong type: %#v", node["tools"])
+	}
+	if len(tools) != 2 {
+		t.Fatalf("node.tools has %d entries, want 2: %#v", len(tools), tools)
+	}
+	first := tools[0].(map[string]interface{})
+	if first["name"] != "one" || first["description"] != "first" {
+		t.Fatalf("tools[0] = %#v", first)
+	}
+	if _, ok := first["schema"].(map[string]interface{}); !ok {
+		t.Fatalf("tools[0].schema not an object: %#v", first["schema"])
+	}
+
+	if skill, _ := node["skill"].(string); skill != "use this toolkit wisely" {
+		t.Fatalf("node.skill = %q, want %q", skill, "use this toolkit wisely")
+	}
+
+	// Toolkit nodes must NOT also carry a `tool` (singular) entry — the
+	// two keys are mutually exclusive by convention.
+	if _, has := node["tool"]; has {
+		t.Fatalf("toolkit node unexpectedly has `tool` key: %#v", node["tool"])
+	}
+}
+
+func TestSpec_SingleToolUnchanged(t *testing.T) {
+	// Back-compat regression: a node embedding runtime.Tool (not Toolkit)
+	// must still emit `tool: {name, description}` and must not carry
+	// `tools` or `skill` unless it also implements SkillProvider.
+	pspec := captureSpec(t, &fxSingleTool{})
+	node := nodeByID(t, pspec, "Test.SingleTool")
+
+	tool, ok := node["tool"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("node.tool missing or wrong type: %#v", node["tool"])
+	}
+	if tool["name"] != "do_thing" || tool["description"] != "does a thing" {
+		t.Fatalf("node.tool = %#v", tool)
+	}
+	if _, has := node["tools"]; has {
+		t.Fatalf("single-tool node unexpectedly has `tools` key: %#v", node["tools"])
+	}
+	if _, has := node["skill"]; has {
+		t.Fatalf("single-tool node unexpectedly has `skill` key: %#v", node["skill"])
+	}
+}
+
+func TestSpec_PlainNodeHasNeitherToolNorToolsNorSkill(t *testing.T) {
+	pspec := captureSpec(t, &fxPlain{})
+	node := nodeByID(t, pspec, "Test.Plain")
+	for _, k := range []string{"tool", "tools", "skill"} {
+		if _, has := node[k]; has {
+			t.Fatalf("plain node unexpectedly carries key %q: %#v", k, node[k])
+		}
+	}
+}
+
+func TestSpec_OptVariableEnumEmitsMultiSelectCheckbox(t *testing.T) {
+	// OptVariable[[]string] + enum must hit the new isVar+isEnum+isOptVar
+	// branch in spec.go: the property's UISchema gets
+	// `ui:field=multiSelectCheckbox`, the schema becomes a `type=array`
+	// with `items.enum`/`items.enumNames`, and formData defaults to [].
+	pspec := captureSpec(t, &fxToolkit{})
+	node := nodeByID(t, pspec, "Test.Toolkit")
+
+	properties, ok := node["properties"].([]interface{})
+	if !ok || len(properties) == 0 {
+		t.Fatalf("node.properties missing or empty: %#v", node["properties"])
+	}
+
+	// The OptVariable lives under the Options property group. Find the
+	// group whose schema.title == "Options".
+	var optsGroup map[string]interface{}
+	for _, p := range properties {
+		pm, _ := p.(map[string]interface{})
+		schema, _ := pm["schema"].(map[string]interface{})
+		if schema["title"] == "Options" {
+			optsGroup = pm
+			break
+		}
+	}
+	if optsGroup == nil {
+		t.Fatalf("Options property group not found: %#v", properties)
+	}
+
+	schemaProps, _ := optsGroup["schema"].(map[string]interface{})["properties"].(map[string]interface{})
+	uiSchema, _ := optsGroup["uiSchema"].(map[string]interface{})
+	formData, _ := optsGroup["formData"].(map[string]interface{})
+
+	optEnabled, ok := schemaProps["optEnabled"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("schema.properties.optEnabled missing: %#v", schemaProps)
+	}
+	if optEnabled["type"] != "array" {
+		t.Fatalf("optEnabled.type = %v, want \"array\"", optEnabled["type"])
+	}
+	if mult, _ := optEnabled["multiple"].(bool); !mult {
+		t.Fatalf("optEnabled.multiple = %v, want true", optEnabled["multiple"])
+	}
+	items, ok := optEnabled["items"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("optEnabled.items missing: %#v", optEnabled)
+	}
+	enum, ok := items["enum"].([]interface{})
+	if !ok || len(enum) != 3 {
+		t.Fatalf("optEnabled.items.enum = %#v, want length 3", items["enum"])
+	}
+	got := make([]string, 0, len(enum))
+	for _, v := range enum {
+		got = append(got, v.(string))
+	}
+	if strings.Join(got, ",") != "a,b,c" {
+		t.Fatalf("items.enum order = %v, want [a b c]", got)
+	}
+
+	if ui, _ := uiSchema["optEnabled"].(map[string]interface{}); ui["ui:field"] != "multiSelectCheckbox" {
+		t.Fatalf("uiSchema.optEnabled.ui:field = %v, want \"multiSelectCheckbox\"", ui["ui:field"])
+	}
+
+	// formData should default to an empty array — when the user picks
+	// nothing, the agent-side reads empty and exposes every tool.
+	arr, ok := formData["optEnabled"].([]interface{})
+	if !ok {
+		t.Fatalf("formData.optEnabled missing or wrong type: %#v", formData["optEnabled"])
+	}
+	if len(arr) != 0 {
+		t.Fatalf("formData.optEnabled = %v, want []", arr)
+	}
+}

--- a/runtime/tool.go
+++ b/runtime/tool.go
@@ -1,5 +1,48 @@
 package runtime
 
-// Tool is a marker struct that indicates a node can be used as an AI tool
-// The actual tool specification and JSON schema generation happens in the Python Agent package
+// Tool is a marker struct that indicates a node can be used as an AI tool.
+// Spec generation reads the `tool:"name=...,description=..."` tag on the
+// embedding struct's Tool field and emits a single tool entry. The runtime
+// ToolInterceptor (tool_interceptor.go) routes incoming tool_request
+// messages to the node's OnMessage and auto-responds via ToolResponse.
 type Tool struct{}
+
+// Toolkit is the multi-tool counterpart of Tool: a node that embeds Toolkit
+// publishes a set of named tools instead of one. Spec generation calls the
+// node's Tools() method (ToolkitProvider) and emits a tools[] array. The
+// agent that consumes the toolkit registers each tool independently, all
+// dispatched to the same node guid; the in-band __tool_name__ discriminator
+// on the message context tells the node's OnMessage which tool was called.
+//
+// A Toolkit node should also implement ToolkitProvider. Optionally, it can
+// implement SkillProvider to ship a markdown system-message addendum that
+// describes how to use the toolkit (the toolkit's AGENT.md).
+type Toolkit struct{}
+
+// ToolDef describes one tool inside a Toolkit. Schema is JSON Schema as a
+// map[string]interface{} so authors can build it in code or load it from
+// an embedded resource. Required is a list of property names that must be
+// supplied — the same shape every modern function-calling API expects.
+type ToolDef struct {
+	Name        string                 `json:"name"`
+	Description string                 `json:"description"`
+	Schema      map[string]interface{} `json:"schema"`
+}
+
+// ToolkitProvider is the optional interface a Toolkit node implements to
+// publish its tool definitions. The spec generator calls Tools() once at
+// package build time. Returning an empty slice is valid (the toolkit
+// publishes no tools and is effectively inert).
+type ToolkitProvider interface {
+	Tools() []ToolDef
+}
+
+// SkillProvider is the optional interface any node (toolkit or single
+// tool) implements to ship a markdown system-message addendum. The
+// consuming agent (Hermes, ADK, …) appends this content to the agent's
+// system message when the node is wired to its tools port. Conceptually
+// the in-tree equivalent of MCP's prompts/get — the behavioral contract
+// travels with the tools.
+type SkillProvider interface {
+	Skill() string
+}

--- a/runtime/tool_response.go
+++ b/runtime/tool_response.go
@@ -10,6 +10,29 @@ func IsToolRequest(ctx message.Context) bool {
 	return msgType == "tool_request"
 }
 
+// ToolName returns the name of the tool the agent invoked for this
+// message. For single-Tool nodes the name matches the node's tool tag and
+// can be ignored. For Toolkit nodes this is the discriminator used to
+// dispatch inside OnMessage. Empty string when ctx is not a tool request.
+func ToolName(ctx message.Context) string {
+	if v, ok := ctx.Get("__tool_name__").(string); ok {
+		return v
+	}
+	return ""
+}
+
+// ToolParameters returns the parsed parameters object the agent passed
+// with the tool call, or an empty map. Empty when ctx is not a tool
+// request. Use the returned map directly, or json.Marshal+Unmarshal it
+// into a typed struct if the schema is stable.
+func ToolParameters(ctx message.Context) map[string]interface{} {
+	v := ctx.Get("__parameters__")
+	if m, ok := v.(map[string]interface{}); ok {
+		return m
+	}
+	return map[string]interface{}{}
+}
+
 // ToolResponse sends a response back to the LLM Agent and prevents message flow
 func ToolResponse(ctx message.Context, status string, data map[string]interface{}, errorMsg string) error {
 	if !IsToolRequest(ctx) {

--- a/runtime/tool_test.go
+++ b/runtime/tool_test.go
@@ -1,0 +1,149 @@
+package runtime
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/robomotionio/robomotion-go/message"
+)
+
+// ToolName + ToolParameters operate on the public message.Context — the
+// helpers should resolve the standard wire fields the agent side sets
+// (`__tool_name__` and `__parameters__`) and degrade gracefully when the
+// envelope is malformed or absent. These cases mirror the corresponding
+// Python tests in robomotion-python/tests/test_tool.py.
+
+func newCtx(raw string) message.Context {
+	return message.NewContext([]byte(raw))
+}
+
+func TestIsToolRequest(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want bool
+	}{
+		{"tool_request", `{"__message_type__":"tool_request"}`, true},
+		{"user_message", `{"__message_type__":"user_message"}`, false},
+		{"missing", `{}`, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := IsToolRequest(newCtx(c.raw)); got != c.want {
+				t.Fatalf("IsToolRequest(%s) = %v, want %v", c.raw, got, c.want)
+			}
+		})
+	}
+}
+
+func TestToolName(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{"set", `{"__tool_name__":"send_message"}`, "send_message"},
+		{"missing", `{}`, ""},
+		// gjson coerces non-string JSON values via Value() — a numeric
+		// tool_name surfaces as float64, which fails the string type-assert
+		// inside ToolName and returns "". That matches the Python helper.
+		{"non_string", `{"__tool_name__":42}`, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := ToolName(newCtx(c.raw)); got != c.want {
+				t.Fatalf("ToolName(%s) = %q, want %q", c.raw, got, c.want)
+			}
+		})
+	}
+}
+
+func TestToolParameters(t *testing.T) {
+	t.Run("present", func(t *testing.T) {
+		ctx := newCtx(`{"__parameters__":{"body":"hi","channel_id":"c1"}}`)
+		got := ToolParameters(ctx)
+		if got["body"] != "hi" || got["channel_id"] != "c1" {
+			t.Fatalf("unexpected params: %#v", got)
+		}
+	})
+	t.Run("missing", func(t *testing.T) {
+		got := ToolParameters(newCtx(`{}`))
+		if got == nil {
+			t.Fatal("ToolParameters returned nil; want empty map")
+		}
+		if len(got) != 0 {
+			t.Fatalf("ToolParameters non-empty for missing: %#v", got)
+		}
+	})
+	t.Run("non_object_returns_empty", func(t *testing.T) {
+		// A string-typed `__parameters__` is malformed but the helper
+		// should not panic — it returns an empty map so callers can
+		// safely range or index without nil checks.
+		got := ToolParameters(newCtx(`{"__parameters__":"bad"}`))
+		if got == nil || len(got) != 0 {
+			t.Fatalf("expected empty map for non-object params, got %#v", got)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// ToolDef + ToolkitProvider + SkillProvider — interface compliance
+// ---------------------------------------------------------------------------
+
+type fakeToolkit struct{}
+
+func (f *fakeToolkit) Tools() []ToolDef {
+	return []ToolDef{
+		{Name: "alpha", Description: "first", Schema: map[string]interface{}{"type": "object"}},
+		{Name: "beta", Description: "second", Schema: map[string]interface{}{"type": "object", "required": []string{"x"}}},
+	}
+}
+
+func (f *fakeToolkit) Skill() string { return "# Skill\nbody" }
+
+func TestToolkitProvider_InterfaceContract(t *testing.T) {
+	var tp ToolkitProvider = &fakeToolkit{}
+	tools := tp.Tools()
+	if len(tools) != 2 {
+		t.Fatalf("Tools() returned %d entries, want 2", len(tools))
+	}
+	if tools[0].Name != "alpha" || tools[1].Name != "beta" {
+		t.Fatalf("unexpected tool names: %v / %v", tools[0].Name, tools[1].Name)
+	}
+	// Schema is a regular map — must round-trip through JSON the way the
+	// spec generator marshals it.
+	raw, err := json.Marshal(tools[0])
+	if err != nil {
+		t.Fatalf("ToolDef JSON marshal failed: %v", err)
+	}
+	var decoded ToolDef
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("ToolDef JSON unmarshal failed: %v", err)
+	}
+	if decoded.Name != "alpha" || decoded.Description != "first" {
+		t.Fatalf("ToolDef did not round-trip: %#v", decoded)
+	}
+}
+
+func TestSkillProvider_InterfaceContract(t *testing.T) {
+	var sp SkillProvider = &fakeToolkit{}
+	if got := sp.Skill(); got != "# Skill\nbody" {
+		t.Fatalf("Skill() = %q, want %q", got, "# Skill\nbody")
+	}
+}
+
+func TestTool_AndToolkit_AreDistinctMarkers(t *testing.T) {
+	// Sanity check: a node embedding runtime.Tool must not be detected
+	// as a Toolkit, and vice versa. The spec generator differentiates
+	// them by field name and emits to different pspec keys.
+	type withTool struct{ Tool }
+	type withToolkit struct{ Toolkit }
+	type withBoth struct {
+		Tool
+		Toolkit
+	}
+
+	var _ = withTool{}
+	var _ = withToolkit{}
+	var _ = withBoth{} // legal Go; spec generator emits both keys
+}


### PR DESCRIPTION
## Summary

Two additive SDK capabilities so any Robomotion package can expose tool
bundles and behavioral guidance to any AI agent (Hermes, ADK,
future...) without the agent package learning anything package-specific.

- `runtime.Toolkit` marker + `ToolDef` + `ToolkitProvider` interface — a
  node publishes N tools from one node. `spec.go` calls `Tools()` and
  emits `tools[]` in the pspec. Agents discover via the existing
  port-connection walk and dispatch by the `__tool_name__` wire field
  over Robomotion's normal `emit_input` bus — same envelope
  `tool_response.go` already speaks for single-Tool nodes (`ToolResponse`,
  `__tool_caller_id__`, `__agent_node_id__`). No new transport.

- `runtime.SkillProvider` — any node ships a markdown system-message
  addendum via `Skill()`. `spec.go` emits it as `skill` on the pspec;
  the consuming agent appends it to the system message when the node is
  wired to the tools port. The in-tree equivalent of MCP `prompts/get`,
  co-located with the tools that need it. Works equally on Toolkit
  nodes, single-Tool nodes, or no-tool helper nodes.

Adds `ToolName(ctx)` and `ToolParameters(ctx)` helpers next to the
existing `IsToolRequest` / `ToolResponse` — mirrors the Python SDK's
`get_tool_parameters`.

Extends spec emission so an `OptVariable[[]string]` field tagged with
`enum` emits as a multi-select checkbox grid (`ui:field=multiSelectCheckbox`,
`items.enum` populated, formData defaults to `[]`). The Designer's
`MultiSelectCheckboxWidget` (separate PR in robomotion-new-designer)
consumes this shape. Used for "which tools should this toolkit expose"
Catch-style filtering on `Toolkit.OptEnabled`.

## Companion PRs

- `robomotion-python` — Python mirror of the same SDK additions.
- `packages-main` — generic Hermes/ADK discovery branches that consume
  `tools[]` + `skill` + the new external-tool wire envelope, plus the
  first concrete Toolkit (agent-teams).

## Test plan

- [ ] `go build ./runtime/` clean (manual: confirmed locally)
- [ ] Generate spec for a node that implements `ToolkitProvider`; verify
      pspec carries `tools: [...]` with name/description/schema per tool.
- [ ] Generate spec for a node that implements `SkillProvider`; verify
      pspec carries `skill: "..."`.
- [ ] OptVariable[[]string]+enum: verify `items.enum` and
      `ui:field=multiSelectCheckbox` land on the option's UISchema.
- [ ] Existing single-Tool nodes (e.g. `monitoring/v1/dns.go`) spec
      output unchanged — `tool: {name, description}` still emitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)