### PR TITLE
Drop unused Setup capability + reconcile bits + IsSetupManaged run-context (v1.20.0)

### DIFF
--- a/CAPABILITIES.md
+++ b/CAPABILITIES.md
@@ -1,0 +1,51 @@
+# Capability bits — canonical registry
+
+Capabilities are a single `uint64` bitfield negotiated between the **robot**
+(deskbot) and a **package** (built on this SDK). The value crosses the wire raw
+(in `GetRobotInfo.capabilities` for robot→package, and the `GetCapabilities`
+RPC for package→robot), so **a bit must mean the same thing on both sides.**
+
+The enum is hand-duplicated in two repos with no compile-time link:
+
+- `robomotion-go/runtime/capabilities.go` (this repo — packages)
+- `robomotion-deskbot/runtime/capabilities.go` (the robot)
+
+**Any change here MUST be mirrored there (and vice-versa).** This file is the
+source of truth for the allocation.
+
+## Allocation
+
+| bit | value | name | direction | meaning |
+|----:|------:|------|-----------|---------|
+| 0 | 1 | _LMOv1Reserved | — | reserved, old file-based LMO; do not reuse |
+| 1 | 2 | IgnoreVersionCheck | robot→package | skip node version gate |
+| 2 | 4 | TerminateOnStop | robot→package | kill package process on stop |
+| 3 | 8 | UseS3 | robot→package | flow assets/artifacts via S3 |
+| 4 | 16 | LMO | both (AND) | content-addressed large-message blob store |
+| 5 | 32 | Diagnostics | robot→package | deskbot stderr diagnostics |
+| 6 | 64 | LazyMessage | robot→package | Go-backed lazy message bridge (Function node) |
+| 7+ | — | (free) | — | next available |
+
+Only **LMO (bit 4)** is intersected via `HasCapability` (robot AND package).
+Everything else is one-directional (`HasRobotCapability`, or the runner reading
+the package's advertised bits, which today only feeds a `[feat:…]` log label and
+the LMO AND).
+
+## Notes / history
+
+- **bit 5 collision + `Setup` removal (v1.20.0).** robomotion-go v1.19.0 had a
+  `Setup` bit at **bit 5** that collided with the deskbot's **`Diagnostics`
+  (bit 5)** / **`LazyMessage` (bit 6)** — the two enums had drifted because the
+  OnSetup work (SDK) and the diagnostics/lazy-message work (deskbot)
+  independently grabbed the next free bit in separate repos. The `Setup` bit was
+  **advertised but never consumed** — OnSetup is gated by the `SetupHandler`
+  interface (at OnSetup-RPC time) + RPC-unimplemented for old packages, not by a
+  capability bit. So v1.20.0 **drops `Setup` entirely** (rather than relocating
+  dead weight) and the SDK adopts `Diagnostics`(5)/`LazyMessage`(6) to match the
+  deskbot. Nets to: no `Setup` bit, enums aligned, bit 7+ free.
+
+- **`setup_managed` is NOT a capability.** Whether interactive setup is
+  host-managed for a run (Agent Hub hire vs custom flow) is run *context*, not a
+  robot ability — it flips per run on the same robot. It travels as a field in
+  the per-run `GetRobotInfo` payload (next to `flow_id`) and is read via
+  `runtime.IsSetupManaged()`. Do **not** allocate a capability bit for it.

--- a/how-to-write-a-package.md
+++ b/how-to-write-a-package.md
@@ -582,10 +582,12 @@ connected robot **outside any flow run** — e.g. inside a hire/onboarding wizar
 and persist the result (a session blob, a token) into the node's bound vault item
 so the real run just works.
 
-It is **opt-in and capability-gated**. A node implements the optional
-`SetupHandler` interface; doing so makes the package automatically advertise
-`CapabilitySetup`. Nodes that don't implement it are unaffected, and older hosts
-that predate `OnSetup` simply never call it — so it is fully backward-compatible.
+It is **opt-in and interface-gated**. A node implements the optional
+`SetupHandler` interface; the host invokes `OnSetup` only on nodes that do.
+Nodes that don't implement it report an unsupported error, and older hosts that
+predate `OnSetup` simply never call it — so it is fully backward-compatible.
+(There is no `OnSetup` capability bit — gating is the interface check, not a
+negotiated capability.)
 
 ```go
 type SetupHandler interface {
@@ -634,8 +636,9 @@ import (
     "github.com/robomotionio/robomotion-go/runtime"
 )
 
-// Connect supports interactive setup. Implementing SetupHandler auto-advertises
-// CapabilitySetup, so the host offers an in-wizard setup step for this node.
+// Connect supports interactive setup. Implementing SetupHandler makes the host
+// offer an in-wizard setup step for this node (gated by the interface, no
+// capability bit).
 func (n *Connect) OnSetup(ctx runtime.SetupContext) error {
     // n.OptCredentials is the bound (possibly empty) vault item — populated
     // from config just like in OnCreate.
@@ -1409,10 +1412,11 @@ SDK features ship without breaking older robots.
 | Capability | Meaning |
 |------------|---------|
 | `CapabilityLMO` | Content-addressed blob store (§20), advertised by the package by default |
-| `CapabilitySetup` | Node implements the `OnSetup` lifecycle (§6.1), auto-advertised when a node implements `SetupHandler` |
-| `CapabilityUseS3`, `CapabilityTerminateOnStop`, `CapabilityIgnoreVersionCheck` | Robot-side runtime behaviors |
+| `CapabilityUseS3`, `CapabilityTerminateOnStop`, `CapabilityIgnoreVersionCheck`, `CapabilityDiagnostics`, `CapabilityLazyMessage` | Robot-side runtime behaviors |
 
-You rarely set these by hand: implementing `SetupHandler` flips
-`CapabilitySetup` for you, and `CapabilityLMO` is on by default. Use
+(`OnSetup` is **not** a capability — it's gated by implementing the
+`SetupHandler` interface; see §6.1. See `CAPABILITIES.md` for the bit registry.)
+
+You rarely set these by hand: `CapabilityLMO` is on by default. Use
 `runtime.HasCapability(cap)` if you need to branch on what the host supports.
 

--- a/proto/plugin.proto
+++ b/proto/plugin.proto
@@ -16,7 +16,7 @@ service Node {
     // duration while emitting prompts via RuntimeHelper.SetupEmit and awaiting
     // user input via RuntimeHelper.SetupAwait, then returns a result. Only
     // nodes that implement the SetupHandler interface respond; others report
-    // an unsupported error. Capability-gated by CapabilitySetup.
+    // an unsupported error. Gated by the SetupHandler interface (no capability bit).
     rpc OnSetup(OnSetupRequest) returns (OnSetupResponse);
 }
 

--- a/runtime/capabilities.go
+++ b/runtime/capabilities.go
@@ -2,13 +2,26 @@ package runtime
 
 type Capability uint64
 
+// Capability bit allocation. THIS MUST STAY IN SYNC WITH
+// robomotion-deskbot/runtime/capabilities.go — the deskbot and SDK each keep a
+// hand-maintained copy and the value crosses the wire as a raw uint64, so a bit
+// that means one thing here and another there silently mis-negotiates. See
+// CAPABILITIES.md for the canonical registry.
+//
+// bit-5 history: v1.19.0 had a `Setup` bit at bit 5 that collided with the
+// deskbot's Diagnostics(5)/LazyMessage(6). It was DROPPED in v1.20.0 — it was
+// advertised but never consumed (OnSetup is gated by the SetupHandler interface
+// + RPC-unimplemented, not a bit), so it was pure dead weight. The SDK now
+// adopts the deskbot's Diagnostics(5)/LazyMessage(6) so the enums align; bit 7+
+// are free.
 const (
 	_CapabilityLMOv1Reserved Capability = 1 << iota // bit 0: RESERVED — old file-based LMO, do not reuse
 	CapabilityIgnoreVersionCheck                     // bit 1
 	CapabilityTerminateOnStop                        // bit 2
 	CapabilityUseS3                                  // bit 3
 	CapabilityLMO                                    // bit 4: content-addressed blob store
-	CapabilitySetup                                  // bit 5: node implements the interactive OnSetup lifecycle
+	CapabilityDiagnostics                            // bit 5: deskbot stderr diagnostics (robot→package; defined for parity)
+	CapabilityLazyMessage                            // bit 6: deskbot Go-backed lazy msg bridge (robot→package; defined for parity)
 )
 
 var (

--- a/runtime/factory.go
+++ b/runtime/factory.go
@@ -45,15 +45,8 @@ func RegisterNodeFactory(name string, factory INodeFactory) {
 	fMux.Lock()
 	defer fMux.Unlock()
 	factories[name] = factory
-
-	// Auto-advertise CapabilitySetup when a registered node type implements
-	// SetupHandler, so GetCapabilities reports setup support without the
-	// package author wiring it by hand.
-	if nf, ok := factory.(*NodeFactory); ok && nf.Type != nil {
-		if reflect.PtrTo(nf.Type).Implements(setupHandlerType) {
-			SetPackageCapability(CapabilitySetup)
-		}
-	}
+	// (OnSetup support is NOT advertised as a capability bit — it's gated by
+	// the SetupHandler interface at OnSetup-RPC time; see setup.go.)
 }
 
 func GetNodeFactory(name string) INodeFactory {

--- a/runtime/properties.go
+++ b/runtime/properties.go
@@ -56,3 +56,26 @@ func GetRobotID() (string, error) {
 
 	return v, nil
 }
+
+// IsSetupManaged reports whether the host manages interactive setup for THIS
+// run — i.e. a setup surface (the Agent Hub hire wizard / OnSetup) exists, so a
+// node should NOT fall back to in-flow pairing (e.g. the WhatsApp/Telegram
+// Receive flow-run QR/token prompt). The deskbot sets it (from AgentHubSlug)
+// in the per-run GetRobotInfo payload, alongside flow_id. This is run CONTEXT,
+// not a capability: it flips per run on the same robot (hub hire vs custom
+// flow). False when absent (older robots / custom & designer flows) so the
+// legacy in-flow pairing remains the default there.
+func IsSetupManaged() bool {
+	info, err := GetRobotInfo()
+	if err != nil {
+		return false
+	}
+	switch v := info["setup_managed"].(type) {
+	case bool:
+		return v
+	case float64: // protobuf Struct encodes some scalars as float64
+		return v != 0
+	default:
+		return false
+	}
+}

--- a/runtime/setup.go
+++ b/runtime/setup.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"reflect"
 )
 
 // SetupHandler is the OPTIONAL lifecycle a node implements to support an
@@ -18,10 +17,6 @@ import (
 type SetupHandler interface {
 	OnSetup(ctx SetupContext) error
 }
-
-// setupHandlerType is used to auto-advertise CapabilitySetup at factory
-// registration when a node type implements SetupHandler.
-var setupHandlerType = reflect.TypeOf((*SetupHandler)(nil)).Elem()
 
 // SetupEvent is one prompt/status frame a node pushes to the UI during setup.
 // Kind tells the UI how to render; Step mirrors the node's setup state


### PR DESCRIPTION
## Capability-bit reconciliation — `Setup` dropped, not relocated
The capability enum is hand-duplicated in `robomotion-go/runtime/capabilities.go` and `robomotion-deskbot/runtime/capabilities.go`, crossing the wire as a raw `uint64`. They had drifted above bit 4: SDK `Setup`=bit5 collided with the deskbot's `Diagnostics`=bit5 / `LazyMessage`=bit6.

Investigation showed the `Setup` bit was **pure dead weight** — `factory.go` advertised it when a node implements `SetupHandler`, but **nothing consumed it**: OnSetup is gated by the `SetupHandler` interface (`AsSetupHandler` at OnSetup-RPC time) + RPC-unimplemented for old packages; and a package's advertised caps only feed a `[feat:…]` log label + the **LMO-only** `HasCapability` AND. The proto/doc comments calling it "capability-gated" were simply inaccurate.

So instead of relocating dead weight, v1.20.0 **drops `Setup`**:
- remove the const + the `factory.go` auto-advertise + the now-unused `setupHandlerType`/`reflect`. OnSetup is unchanged (never needed the bit).
- adopt `Diagnostics`(5) + `LazyMessage`(6) to match the deskbot → enums aligned, bit 7+ free.
- `CAPABILITIES.md` canonical registry + sync warning; fixed the docs/proto comment.

## IsSetupManaged() — run context, not a capability
`runtime.IsSetupManaged()` tells a node whether the host manages interactive setup for **this run** (Agent Hub hire wizard / OnSetup) so it should skip in-flow pairing. Run *context* (flips per run on the same robot), so it rides the per-run `GetRobotInfo` payload next to `flow_id`, not the capability bitfield. False when absent → older robots / custom & designer flows keep legacy in-flow pairing.

**Pairs with:** deskbot PR #2651 (emit `setup_managed` + align bits). **Release as v1.20.0** once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)