### PR TITLE
fix(oauth): escape reflected error params in callback page (XSS)

### DIFF
--- a/runtime/oauth.go
+++ b/runtime/oauth.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"context"
 	"fmt"
+	"html"
 	"log"
 	"net"
 	"net/http"
@@ -111,7 +112,7 @@ func OpenOAuthDialog(cfg *oauth2.Config) (string, error) {
 <body>
 	<div class="container">
 		<h1>Authorization Failed</h1>
-		<p>` + errMsg + `</p>
+		<p>` + html.EscapeString(errMsg) + `</p>
 		<p>You can close this window and try again.</p>
 	</div>
 </body>


### PR DESCRIPTION
Escapes the `error`/`error_description` query params before echoing them into the local OAuth callback HTML page. Fixes code scanning `go/reflected-xss` at runtime/oauth.go. Low impact (loopback callback server) but trivially fixed with `html.EscapeString`.